### PR TITLE
Update site.rb

### DIFF
--- a/lib/wordstress/site.rb
+++ b/lib/wordstress/site.rb
@@ -58,7 +58,7 @@ module Wordstress
         return JSON.parse(json)
       rescue => e
         $logger.err e.message
-        @online = false
+        @online = false unless e.message.include?"403"
         return JSON.parse("{}")
       end
     end
@@ -70,7 +70,7 @@ module Wordstress
         return JSON.parse(json)
       rescue => e
         $logger.err e.message
-        @online = false
+        @online = false unless e.message.include?"403"
         return JSON.parse("{}")
       end
     end
@@ -82,7 +82,7 @@ module Wordstress
         return JSON.parse("{\"wordpress\":{\"vulnerabilities\":[]}}") if page.class == Net::HTTPNotFound
       rescue => e
         $logger.err e.message
-        @online = false
+        @online = false unless e.message.include?"403"
         return JSON.parse("{}")
       end
     end


### PR DESCRIPTION
Prevent failure on 403 encounter. Don't know which URL's are forbidden, but its a specific http state not a connection error. So therefore it shouldnt fail
E.g. https://wpvulndb.com/api/v1/plugins/hello.php gives a 403